### PR TITLE
Update php version for D8

### DIFF
--- a/islandora_pdfjs.info.yml
+++ b/islandora_pdfjs.info.yml
@@ -4,5 +4,5 @@ package: 'Islandora Viewers'
 dependencies:
   - libraries:libraries
 core: 8.x
-php: '5.5.9'
+php: '7.2'
 type: module


### PR DESCRIPTION
php 5 support is being dropped:
[Drupal docs](https://www.drupal.org/docs/8/system-requirements/php-requirements)